### PR TITLE
Normalize indentation to 2 spaces in css files

### DIFF
--- a/css/style1.css
+++ b/css/style1.css
@@ -6,12 +6,12 @@
  */
 
 body {
-    padding: 30px;
-    background-color: #7A0019;
-    display: flex; /* this is the flexbox model. It adds responsive design to its items */
-    flex-direction: column; /* this says how the flex items will align (e.g. 'row') */
-    align-items: center; /* These next two properties center the flex items */
-    justify-content: center;
+  padding: 30px;
+  background-color: #7A0019;
+  display: flex; /* this is the flexbox model. It adds responsive design to its items */
+  flex-direction: column; /* this says how the flex items will align (e.g. 'row') */
+  align-items: center; /* These next two properties center the flex items */
+  justify-content: center;
 }
 
 /*
@@ -20,11 +20,11 @@ body {
  * them side-by-side.
  */
 @media screen and (min-width: 925px) {
-    .pslo-courses-container {
-      display: flex;
-      flex-direction: row;
-      max-width: 53em;
-    }
+  .pslo-courses-container {
+    display: flex;
+    flex-direction: row;
+    max-width: 53em;
+  }
 }
 
 .faculty-container {
@@ -35,58 +35,58 @@ body {
 }
 
 #main-title {
-    color: #FFDE7A;
-    font-family: 'Patua One', monospace;
-    text-align: center;
-    font-size: 4rem
+  color: #FFDE7A;
+  font-family: 'Patua One', monospace;
+  text-align: center;
+  font-size: 4rem
 }
 
 h2 {
-    font-family: 'EB Garamond', serif;
+  font-family: 'EB Garamond', serif;
 }
 
 .section {
-    border-radius: 25px;
-    padding: 20px;
-    border: 5px solid;
-    margin: 10px;
-    max-width: 48em;
+  border-radius: 25px;
+  padding: 20px;
+  border: 5px solid;
+  margin: 10px;
+  max-width: 48em;
 }
 
 #courses {
-    background-color: #FFDE7A;
-    font-family: 'Marcellus', sans-serif;
+  background-color: #FFDE7A;
+  font-family: 'Marcellus', sans-serif;
 }
 
 #pslo {
-    background-color: #d5d6d2;
-    font-family: 'Marcellus', sans-serif;
+  background-color: #d5d6d2;
+  font-family: 'Marcellus', sans-serif;
 }
 
 #faculty {
-    background-color: #f9f7f6;
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-content: center;
+  background-color: #f9f7f6;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-content: center;
 }
 
 #faculty>ul>li {
-    display: inline-block;
-    font-family: sans-serif;
-    padding: 30px;
+  display: inline-block;
+  font-family: sans-serif;
+  padding: 30px;
 }
 
 #faculty-list {
-    padding-left: 0;
-    display: flex;
-    flex-direction: row;
-    flex-wrap: wrap; /* This tell's the flex items to wrap if there
-                        isn't enough space for all of the items. Without this the
-                        faculty images will be in a row and only resize well unitl around
-                        550px width of screen. */
-    justify-content: center;
-    align-content: center;
+  padding-left: 0;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap; /* This tell's the flex items to wrap if there
+                      isn't enough space for all of the items. Without this the
+                      faculty images will be in a row and only resize well unitl around
+                      550px width of screen. */
+  justify-content: center;
+  align-content: center;
 }
 
 .name {
@@ -99,43 +99,43 @@ h2 {
 }
 
 img.pic {
-    width: 100%;
-    border: 4px solid #000000;
+  width: 100%;
+  border: 4px solid #000000;
 }
 
 #style ul {
-    list-style-type: none;
-    margin: 0;
-    padding: 0;
-    overflow: hidden;
-    background-color: #333;
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+  overflow: hidden;
+  background-color: #333;
 }
 
 #style li {
-    float: left; /*explore what happens if this is 'right' instead*/
+  float: left; /*explore what happens if this is 'right' instead*/
 }
 
 #style li a {
-    display: block;
-    color: white;
-    text-align: center;
-    padding: 14px 16px; /*this adds some spacing around the items in our "nav bar" */
-    text-decoration: none;
+  display: block;
+  color: white;
+  text-align: center;
+  padding: 14px 16px; /*this adds some spacing around the items in our "nav bar" */
+  text-decoration: none;
 }
 
 /* Change the link background color to #000 (black) on hover */
 #style li a:hover {
-    background-color: #000;
+  background-color: #000;
 }
 
 #style {
-    position: fixed;
-    background-color: #7A0019;
-    left: 0;
-    right: 0;
-    top: 0;
-    height: 55px;
-    padding-top: 10px;
+  position: fixed;
+  background-color: #7A0019;
+  left: 0;
+  right: 0;
+  top: 0;
+  height: 55px;
+  padding-top: 10px;
 }
 
 #validation {

--- a/css/style2.css
+++ b/css/style2.css
@@ -7,6 +7,6 @@ use float to make something locate itself on the right or left
 */
 
 body{
-    padding: 30px;
-    background-color: #ffffff;
+  padding: 30px;
+  background-color: #ffffff;
 }


### PR DESCRIPTION
Previously, these files used a mix of 2-space and 4-space indentation.

I chose to make everything use 2 spaces rather than 4 for consistency with `index.html`, which uses 2 spaces, and for consistency with `.editorconfig`, which asserts that css files have two-space indentation.

This addresses issue #42.