### PR TITLE
Remove the "Bracket Pair Colorizer" extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -8,10 +8,6 @@
       // https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig
       "EditorConfig.EditorConfig",
 
-      // Bracket Pair Colorizer 2
-      // https://marketplace.visualstudio.com/items?itemName=CoenraadS.bracket-pair-colorizer-2
-      "CoenraadS.bracket-pair-colorizer-2",
-
       // Markdown All in One
       // https://marketplace.visualstudio.com/items?itemName=yzhang.markdown-all-in-one
       "yzhang.markdown-all-in-one",


### PR DESCRIPTION
This is now built-in to VS Code, so we want to remove this so people don't get warnings about it.