### PR TITLE
Add markdown link check to `github/settings.yml`

### DIFF
--- a/.github/mlc_config.json
+++ b/.github/mlc_config.json
@@ -1,0 +1,7 @@
+{
+    "ignorePatterns": [
+      {
+        "pattern": "^\.\./\.\./actions/workflows"
+      }
+    ]
+  }

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -37,7 +37,7 @@ branches:
         # Required. Require branches to be up to date before merging.
         strict: true
         # Required. The list of status checks to require in order to merge into this branch
-        contexts: ['AccessLint']
+        contexts: ['markdown-link-check', 'AccessLint']
       # Required. Enforce all configured restrictions for administrators. Set to true to enforce required status checks for repository administrators. Set to null to disable.
       enforce_admins: true
       # Required. Restrict who can push to this branch. Team and user restrictions are only available for organization-owned repositories. Set to null to disable.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # CSci 3601 Lab #1 - HTML and CSS Lab <!-- omit in toc -->
 
+[![Check Markdown links](../../actions/workflows/link-check.yaml/badge.svg)](../../actions/workflows/link-check.yaml)
+
 - [Setup Instructions](#setup-instructions)
 - ["Running" your project](#running-your-project)
   - [Our Team's GitHub Pages URL](#our-teams-github-pages-url)


### PR DESCRIPTION
I forgot to add this to `settings.yml`, so it wouldn't propogate properly to copies of the repo.

I also added a Markdown Link Check badge.